### PR TITLE
Select frames for editing

### DIFF
--- a/animationview.cpp
+++ b/animationview.cpp
@@ -7,10 +7,10 @@ AnimationView::AnimationView(QWidget *parent) :
     this->setAlignment(Qt::AlignCenter);
     this->setFixedSize(Globals::ANIMATION_WINDOW_SIZE_X+2, Globals::ANIMATION_WINDOW_SIZE_Y+2);
 //    tool = this->DRAW;
-    Frame * frame = new Frame(0, 0);
+   /* Frame * frame = new Frame(0, 0);
     this->setScene(frame);
     baseObject = new Object();
-    frame->addItem(baseObject);
+    frame->addItem(baseObject);*/
     mouseClicked = false;
 }
 
@@ -56,6 +56,16 @@ void AnimationView::saveFrame()
 void AnimationView::loadFrame()
 {
 
+}
+
+void AnimationView::displaySelected(Frame *scene)
+{
+    this->setScene(scene);
+}
+
+void AnimationView::acceptFrameConnection(Frame *frame)
+{
+    connect(frame, SIGNAL(iWasSelected(Frame*)), this, SLOT(displaySelected(Frame*)));
 }
 
 /**

--- a/animationview.h
+++ b/animationview.h
@@ -39,6 +39,8 @@ public slots:
     void getTower();
     void saveFrame();
     void loadFrame();
+    void displaySelected(Frame*);
+    void acceptFrameConnection(Frame*);
 
 private slots:
     void drawBackground(QPainter *painter, const QRectF &rect);

--- a/frame.cpp
+++ b/frame.cpp
@@ -81,6 +81,8 @@ void Frame::mousePressEvent(QGraphicsSceneMouseEvent *mouseEvent)
 {
     mouseClicked = true;
 
+    emit iWasSelected(this);
+
     switch (tool){
     case Globals::ERASE_TOOL:
         //getTowerContents();

--- a/frame.h
+++ b/frame.h
@@ -1,16 +1,22 @@
 #ifndef FRAME_H
 #define FRAME_H
+#include <QObject>
 #include <QGraphicsScene>
 #include <QGraphicsRectItem>
 #include <QGraphicsSceneMouseEvent>
+#include "frame.h"
 #include "global.h"
 #include "pixel.h"
 #include <QDebug>
 
 class Frame : public QGraphicsScene
 {
+    Q_OBJECT
+signals:
+    void iWasSelected(Frame*);
 public:
     Frame(int frameNum=0, double frameDuration=0);
+    virtual ~Frame() {};
     void setTool(int t);
     void setRed(int r);
     void setGreen(int g);

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -12,14 +12,25 @@ MainWindow::MainWindow(QWidget *parent) :
 {
     ui->setupUi(this);
 
-    TimelineGraphics timeline;
-//    ui->scrollArea->setWidget(timeline.timelineWidget());
+    TimelineGraphics* timeline = new TimelineGraphics;
+    ui->timelineArea->setWidget(timeline->timelineWidget());
     // make timeline instance
 
     //connect draw and erase buttons to the tool variable in AnimationView
     connect(ui->drawButton, SIGNAL (released()), this, SLOT (drawButtonPress()));
     connect(ui->eraseButton, SIGNAL (released()), this, SLOT (eraseButtonPress()));
     connect(ui->moveButton, SIGNAL (released()), this, SLOT (moveButtonPress()));
+    connect(timeline, SIGNAL( testSignal(QGraphicsScene*)), ui->AnimationWidget, SLOT(sceneSelected(QGraphicsScene*)));
+    connect(timeline, SIGNAL(connectNewFrame(Frame*)), ui->AnimationWidget, SLOT(acceptFrameConnection(Frame*)));
+
+    timeline->addTimelineFrame();
+    timeline->addTimelineFrame();
+
+    timeline->addTimelineFrame();
+    timeline->addTimelineFrame();
+    timeline->addTimelineFrame();
+    timeline->addTimelineFrame();
+    timeline->addTimelineFrame();
 
 }
 

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -298,7 +298,7 @@
     <item>
      <layout class="QVBoxLayout" name="timeLineLayout">
       <item>
-       <widget class="QScrollArea" name="timeLinePlaceHolder">
+       <widget class="QScrollArea" name="timelineArea">
         <property name="widgetResizable">
          <bool>true</bool>
         </property>

--- a/timelinegraphics.cpp
+++ b/timelinegraphics.cpp
@@ -1,4 +1,5 @@
 #include "timelinegraphics.h"
+#include "frame.h"
 #include <QHBoxLayout>
 #include <QGraphicsScene>
 #include <QGraphicsView>
@@ -7,6 +8,7 @@
 TimelineGraphics::TimelineGraphics()
 {
     timeline = new QWidget;
+    layout = new QHBoxLayout;
     loadTimeline();
 }
 
@@ -15,13 +17,13 @@ QWidget* TimelineGraphics::timelineWidget()
     return timeline;
 }
 
-void TimelineGraphics::loadTimeline() {
-    layout = new QHBoxLayout;
-    for(int i=0; i<50; i++) {
-        addTimelineFrame(layout);
+void TimelineGraphics::loadTimeline()
+{
+    for(int i=0; i<1; i++) {
+        addTimelineFrame();
     }
 
-    timeline->setLayout(layout);
+    timeline->setLayout(this->layout);
     timeline->setMaximumHeight(500);
 }
 
@@ -32,18 +34,21 @@ void TimelineGraphics::addFramePixel(QGraphicsScene* scene, int x, int y)
    scene->addItem(item1);
 }
 
-void TimelineGraphics::addTimelineFrame(QHBoxLayout* layout )
+void TimelineGraphics::addTimelineFrame()
 {
     QGraphicsView* view = new QGraphicsView;
-       QGraphicsScene* scene = new QGraphicsScene;
-          scene->addText("frame #");
+       Frame* scene = new Frame;
+         /* scene->addText("frame #");
 
           for(int x=0; x<4; x++) {
               for(int y=0; y<10; y++) {
                   addFramePixel(scene, x, y);
               }
-          }
+          }*/
     view->setScene(scene);
     view->setMaximumWidth(100);
-    layout->addWidget(view);
+    emit connectNewFrame(scene);
+    this->layout->addWidget(view);
 }
+
+

--- a/timelinegraphics.h
+++ b/timelinegraphics.h
@@ -1,24 +1,28 @@
 #ifndef TIMELINEGRAPHICS_H
 #define TIMELINEGRAPHICS_H
 
+#include "frame.h"
 #include <QMainWindow>
 #include <QObject>
 #include <QWidget>
 #include <QHBoxLayout>
 #include <QGraphicsScene>
 
-class TimelineGraphics
+class TimelineGraphics : public QObject
 {
+    Q_OBJECT
+signals:
+    void connectNewFrame(Frame*);
 public:
     TimelineGraphics();
     void loadTimeline();
     void addFramePixel(QGraphicsScene* scene, int x, int y);
     QWidget* timelineWidget();
+    void addTimelineFrame();
 
 private:
     QWidget* timeline;
     QHBoxLayout* layout;
-    void addTimelineFrame(QHBoxLayout* layout );
 
 };
 


### PR DESCRIPTION
Implemented slots and signals for AnimationView, Frame, and TimelineGraphics, so that frames can be selected from the timeline and displayed in the animationview. The scaling and sizes aren't set up yet so there are odd scroll bars. 
![image](https://cloud.githubusercontent.com/assets/16008906/20829177/d5941b14-b82f-11e6-9e65-7fb0363ac8fa.png)
