### PR TITLE
Playback

### DIFF
--- a/TowerAnimator.pro
+++ b/TowerAnimator.pro
@@ -4,7 +4,8 @@
 #
 #-------------------------------------------------
 
-QT       += core gui
+QT       += core gui \
+            testlib
 
 greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
 

--- a/animationview.cpp
+++ b/animationview.cpp
@@ -14,28 +14,15 @@ void AnimationView::setTool(int x)
     if(currentFrame != 0)
         currentFrame->setTool(x);
 }
-//void AnimationView::setRed(int r)
-//{
-//    if(currentFrame != 0)
-//        currentFrame->setRed(r);
-//}
-
-//void AnimationView::setGreen(int g)
-//{
-//    if(currentFrame != 0)
-//        currentFrame->setGreen(g);
-//}
-
-//void AnimationView::setBlue(int b)
-//{
-//    if(currentFrame != 0)
-//        currentFrame->setBlue(b);
-//}
 
 void AnimationView::colorChange(const QColor &color)
 {
-    qDebug() << "color changed to: " << color;
-    emit setFrameColor(color);
+
+    currentColor.setRed(color.red());
+    currentColor.setGreen(color.green());
+    currentColor.setBlue(color.blue());
+    //qDebug() << "color changed to: " << color;
+    emit setFrameColor(currentColor);
 }
 
 /**
@@ -68,12 +55,13 @@ void AnimationView::displaySelected(TimelineView *view)
 {
     this->setScene(view->frame);
     currentFrame = view->frame;
+    emit setFrameColor(currentColor);
 }
 
 void AnimationView::acceptFrameConnection(TimelineView *view)
 {
     connect(view, SIGNAL(iWasSelected(TimelineView*)), this, SLOT(displaySelected(TimelineView*)));
-    connect(this, SIGNAL(setFrameColor(const QColor &)), view->frame, SLOT(colorChange(const QColor &)));
+    connect(this, SIGNAL(setFrameColor(QColor)), view->frame, SLOT(colorChange(QColor)));
 }
 
 /**

--- a/animationview.cpp
+++ b/animationview.cpp
@@ -14,27 +14,28 @@ void AnimationView::setTool(int x)
     if(currentFrame != 0)
         currentFrame->setTool(x);
 }
-void AnimationView::setRed(int r)
-{
-    if(currentFrame != 0)
-        currentFrame->setRed(r);
-}
+//void AnimationView::setRed(int r)
+//{
+//    if(currentFrame != 0)
+//        currentFrame->setRed(r);
+//}
 
-void AnimationView::setGreen(int g)
-{
-    if(currentFrame != 0)
-        currentFrame->setGreen(g);
-}
+//void AnimationView::setGreen(int g)
+//{
+//    if(currentFrame != 0)
+//        currentFrame->setGreen(g);
+//}
 
-void AnimationView::setBlue(int b)
-{
-    if(currentFrame != 0)
-        currentFrame->setBlue(b);
-}
+//void AnimationView::setBlue(int b)
+//{
+//    if(currentFrame != 0)
+//        currentFrame->setBlue(b);
+//}
 
-void AnimationView::colorChange(QColor* color)
+void AnimationView::colorChange(const QColor &color)
 {
-
+    qDebug() << "color changed to: " << color;
+    emit setFrameColor(color);
 }
 
 /**
@@ -72,7 +73,7 @@ void AnimationView::displaySelected(TimelineView *view)
 void AnimationView::acceptFrameConnection(TimelineView *view)
 {
     connect(view, SIGNAL(iWasSelected(TimelineView*)), this, SLOT(displaySelected(TimelineView*)));
-    connect(this, SIGNAL(setFrameColor(QColor*)), view->frame, SLOT(colorChange(QColor*)));
+    connect(this, SIGNAL(setFrameColor(const QColor &)), view->frame, SLOT(colorChange(const QColor &)));
 }
 
 /**

--- a/animationview.h
+++ b/animationview.h
@@ -29,13 +29,10 @@ public:
     explicit AnimationView(QWidget *parent = 0);
 
 signals:
-    void setFrameColor(const QColor &);
+    void setFrameColor(QColor);
 
 public slots:
     void setTool(int);
-//    void setRed(int);
-//    void setGreen(int);
-//    void setBlue(int);
     void getTower();
     void saveFrame();
     void loadFrame(Frame*);
@@ -47,6 +44,7 @@ private slots:
     void drawBackground(QPainter *painter, const QRectF &rect);
 private:
     Frame * currentFrame;
+    QColor currentColor;
 };
 
 #endif // ANIMATIONVIEW_H

--- a/animationview.h
+++ b/animationview.h
@@ -8,6 +8,7 @@
 #include <QPointF>
 #include <QDebug>
 #include <QColor>
+#include <QDebug>
 
 #include "global.h"
 #include "pixel.h"
@@ -28,19 +29,19 @@ public:
     explicit AnimationView(QWidget *parent = 0);
 
 signals:
-    void setFrameColor(QColor*);
+    void setFrameColor(const QColor &);
 
 public slots:
     void setTool(int);
-    void setRed(int);
-    void setGreen(int);
-    void setBlue(int);
+//    void setRed(int);
+//    void setGreen(int);
+//    void setBlue(int);
     void getTower();
     void saveFrame();
     void loadFrame(Frame*);
     void displaySelected(TimelineView *);
     void acceptFrameConnection(TimelineView *framView);    
-    void colorChange(QColor*);
+    void colorChange(const QColor &);
 
 private slots:
     void drawBackground(QPainter *painter, const QRectF &rect);

--- a/frame.cpp
+++ b/frame.cpp
@@ -19,32 +19,15 @@ void Frame::setTool(int t)
     tool = t;
 }
 
-void Frame::colorChange(const QColor &color)
+void Frame::colorChange(QColor color)
 {
-    int *r, *g, *b;
-    //color.getRgb(r, g, b)
-    qDebug() << "redColor: " << color.red();
+    //qDebug() << "redColor: " << color.red();
     drawColor.setRed(color.red());
     drawColor.setGreen(color.green());
     drawColor.setBlue(color.blue());
-    qDebug() << drawColor;
-}
-/*
-void Frame::setRed(int r)
-{
-    drawColor.setRed(r);
+    //qDebug() << drawColor;
 }
 
-void Frame::setGreen(int g)
-{
-    drawColor.setGreen(g);
-}
-
-void Frame::setBlue(int b)
-{
-    drawColor.setBlue(b);
-}
-*/
 QList<Pixel *> Frame::getPixels()
 {
     //get a list of the pixels that are in the scene

--- a/frame.cpp
+++ b/frame.cpp
@@ -3,10 +3,11 @@
 
 Frame::Frame(int frameNum, double frameDuration)
 {
+    duration = 1;
     duration = frameDuration;
     frameNumber = frameNum;
     tool = Globals::DRAW_TOOL;
-    duration = 1;
+
     mouseClicked = false;
 
     this->setSceneRect(0,0,Globals::ANIMATION_WINDOW_SIZE_X,Globals::ANIMATION_WINDOW_SIZE_Y);
@@ -136,6 +137,11 @@ void Frame::drawPixel(QGraphicsSceneMouseEvent *mouseEvent)
         //Add it to the object
         //    baseObject->addToGroup(pixel);
     }
+}
+
+void Frame::addPixel(Pixel *pixel)
+{
+    this->addItem(pixel);
 }
 
 bool Frame::isInBounds(QPointF pt)

--- a/frame.cpp
+++ b/frame.cpp
@@ -19,15 +19,17 @@ void Frame::setTool(int t)
     tool = t;
 }
 
-void Frame::colorChange(QColor* color)
+void Frame::colorChange(const QColor &color)
 {
-    int* r, g, b;
-    color->getRgb(r, g, b);
-    setRed(r);
-    setGreen(g);
-    setBlue(b);
+    int *r, *g, *b;
+    //color.getRgb(r, g, b)
+    qDebug() << "redColor: " << color.red();
+    drawColor.setRed(color.red());
+    drawColor.setGreen(color.green());
+    drawColor.setBlue(color.blue());
+    qDebug() << drawColor;
 }
-
+/*
 void Frame::setRed(int r)
 {
     drawColor.setRed(r);
@@ -42,7 +44,7 @@ void Frame::setBlue(int b)
 {
     drawColor.setBlue(b);
 }
-
+*/
 QList<Pixel *> Frame::getPixels()
 {
     //get a list of the pixels that are in the scene

--- a/frame.h
+++ b/frame.h
@@ -17,9 +17,6 @@ public:
     Frame(int frameNum=0, double frameDuration=0);
     virtual ~Frame() {};
     void setTool(int t);
-    void setRed(int r);
-    void setGreen(int g);
-    void setBlue(int b);
 
     //storage info
     double duration;
@@ -29,7 +26,7 @@ public:
     void write();
 
 public slots:
-    void colorChange(const QColor &);
+    void colorChange(QColor);
 private:
     QGraphicsRectItem * tower;
     void mouseMoveEvent(QGraphicsSceneMouseEvent * mouseEvent);

--- a/frame.h
+++ b/frame.h
@@ -25,6 +25,7 @@ public:
     QList<class Pixel *> getTowerContents();
     void write();
 
+    void addPixel(Pixel *pixel);
 public slots:
     void colorChange(QColor);
 private:

--- a/frame.h
+++ b/frame.h
@@ -29,7 +29,7 @@ public:
     void write();
 
 public slots:
-    void colorChange(QColor *);
+    void colorChange(const QColor &);
 private:
     QGraphicsRectItem * tower;
     void mouseMoveEvent(QGraphicsSceneMouseEvent * mouseEvent);

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -16,25 +16,25 @@ MainWindow::MainWindow(QWidget *parent) :
     ui->setupUi(this);
     QColorDialog* colorDialog = new QColorDialog(QColorDialog::NoButtons);
     colorDialog->setOption(QColorDialog::NoButtons | QColorDialog::DontUseNativeDialog);
-    //ui->AnimationWidget->colorChange(colorDialog->currentColor());
-    //QColor colortype = colorDialog->currentColor();
-    //qDebug() << "color name:";
-    //qDebug() << colortype.name();
+
     ui->colorSelector->addWidget(colorDialog);
     connect(colorDialog, SIGNAL(currentColorChanged(const QColor &)), ui->AnimationWidget, SLOT(colorChange(const QColor &)));
 
+    // make timeline instance
     TimelineGraphics* timeline = new TimelineGraphics;
     ui->timelineArea->setWidget(timeline->timelineWidget());
-    // make timeline instance
 
-    //connect draw and erase buttons to the tool variable in AnimationView
+    //connect ui main buttons
     connect(ui->drawButton, SIGNAL (released()), this, SLOT (drawButtonPress()));
     connect(ui->eraseButton, SIGNAL (released()), this, SLOT (eraseButtonPress()));
     connect(ui->moveButton, SIGNAL (released()), this, SLOT (moveButtonPress()));
     connect(ui->AddFrame, SIGNAL(released()), timeline, SLOT (addTimelineFrame()));
-    connect(timeline, SIGNAL( testSignal(Frame*)), ui->AnimationWidget, SLOT(loadFrame(Frame*)));
-    connect(timeline, SIGNAL(connectNewFrame(TimelineView*)), ui->AnimationWidget, SLOT(acceptFrameConnection(TimelineView*)));
     connect(ui->delteFrame, SIGNAL(released()), timeline, SLOT(deleteCurrentView()));
+
+    connect(timeline, SIGNAL(connectNewFrame(TimelineView*)), ui->AnimationWidget, SLOT(acceptFrameConnection(TimelineView*)));
+
+    //add first frame
+    timeline->addTimelineFrame();
 
 }
 

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -14,6 +14,7 @@ MainWindow::MainWindow(QWidget *parent) :
     ui(new Ui::MainWindow)
 {
     ui->setupUi(this);
+    rf = new readfile;
     QColorDialog* colorDialog = new QColorDialog(QColorDialog::NoButtons);
     colorDialog->setOption(QColorDialog::NoButtons | QColorDialog::DontUseNativeDialog);
 
@@ -30,8 +31,11 @@ MainWindow::MainWindow(QWidget *parent) :
     connect(ui->moveButton, SIGNAL (released()), this, SLOT (moveButtonPress()));
     connect(ui->AddFrame, SIGNAL(released()), timeline, SLOT (addTimelineFrame()));
     connect(ui->delteFrame, SIGNAL(released()), timeline, SLOT(deleteCurrentView()));
+    connect(ui->playback, SIGNAL(released()), timeline, SLOT(playback()));
 
     connect(timeline, SIGNAL(connectNewFrame(TimelineView*)), ui->AnimationWidget, SLOT(acceptFrameConnection(TimelineView*)));
+
+    connect(rf, SIGNAL(loadFrame(Frame*)), timeline, SLOT(addTimelineFrame(Frame*)));
 
     //add first frame
     timeline->addTimelineFrame();
@@ -138,8 +142,8 @@ void MainWindow::on_actionImport_triggered()
     // get the file name and location import file
     fileName = QFileDialog::getOpenFileName(this,
     tr("Open File"), "/home/", tr("Tan Files (*.tan *.tan2)"));
-    readfile f;
-    f.read(fileName);
+    //readfile f;
+    rf->read(fileName);
 }
 
 void MainWindow::on_actionExport_triggered()

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -22,7 +22,7 @@ MainWindow::MainWindow(QWidget *parent) :
     connect(colorDialog, SIGNAL(currentColorChanged(const QColor &)), ui->AnimationWidget, SLOT(colorChange(const QColor &)));
 
     // make timeline instance
-    TimelineGraphics* timeline = new TimelineGraphics;
+    timeline = new TimelineGraphics;
     ui->timelineArea->setWidget(timeline->timelineWidget());
 
     //connect ui main buttons
@@ -34,6 +34,7 @@ MainWindow::MainWindow(QWidget *parent) :
     connect(ui->restart, SIGNAL(released()), timeline, SLOT(restartPlayback()));
     connect(ui->resume, SIGNAL(released()), timeline, SLOT(resumePlayback()));
     connect(ui->stop, SIGNAL(released()), timeline, SLOT(stopPlayback()));
+    connect(timeline, SIGNAL(scrollToSelected(TimelineView*)), this, SLOT(ScrollToSelected(TimelineView*)));
 
     connect(timeline, SIGNAL(connectNewFrame(TimelineView*)), ui->AnimationWidget, SLOT(acceptFrameConnection(TimelineView*)));
 
@@ -47,6 +48,17 @@ MainWindow::MainWindow(QWidget *parent) :
 MainWindow::~MainWindow()
 {
     delete ui;
+}
+
+void MainWindow::ScrollToSelected(TimelineView* view)
+{
+    qDebug() << "signaled";
+    if(!rf->loading && !timeline->isPlaying)
+        QTest::qWait(2);
+    ui->timelineArea->ensureVisible(view->pos().x()+100, 1);
+    ui->timelineArea->ensureVisible(view->pos().x(), 1);
+
+    //ui->timelineArea->ensureVisible(100000000, 0, 0, 0);
 }
 
 void MainWindow::drawButtonPress()

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -7,6 +7,7 @@
 #include <QMessageBox>
 #include <QFileDialog>
 #include <QColorDialog>
+#include <QDebug>
 
 MainWindow::MainWindow(QWidget *parent) :
     QMainWindow(parent),
@@ -14,9 +15,13 @@ MainWindow::MainWindow(QWidget *parent) :
 {
     ui->setupUi(this);
     QColorDialog* colorDialog = new QColorDialog(QColorDialog::NoButtons);
-    colorDialog->setOption(QColorDialog::NoButtons, true);
+    colorDialog->setOption(QColorDialog::NoButtons | QColorDialog::DontUseNativeDialog);
+    //ui->AnimationWidget->colorChange(colorDialog->currentColor());
+    //QColor colortype = colorDialog->currentColor();
+    //qDebug() << "color name:";
+    //qDebug() << colortype.name();
     ui->colorSelector->addWidget(colorDialog);
-    connect(colorDialog, SIGNAL(currentColorChanged(QColor*)), ui->AnimationWidget, SLOT(colorChange(QColor*)));
+    connect(colorDialog, SIGNAL(currentColorChanged(const QColor &)), ui->AnimationWidget, SLOT(colorChange(const QColor &)));
 
     TimelineGraphics* timeline = new TimelineGraphics;
     ui->timelineArea->setWidget(timeline->timelineWidget());
@@ -59,21 +64,21 @@ void MainWindow::moveButtonPress()
 
 void MainWindow::on_redLineEdit_textEdited(const QString &arg1)
 {
-    ui->AnimationWidget->setRed(arg1.toInt());
-    editedSinceLastSave = true;
+//    ui->AnimationWidget->setRed(arg1.toInt());
+//    editedSinceLastSave = true;
 }
 
 void MainWindow::on_greenLineEdit_textEdited(const QString &arg1)
 {
-    ui->AnimationWidget->setGreen(arg1.toInt());
-    editedSinceLastSave = true;
+//    ui->AnimationWidget->setGreen(arg1.toInt());
+//    editedSinceLastSave = true;
 
 }
 
 void MainWindow::on_blueLineEdit_textEdited(const QString &arg1)
 {
-    ui->AnimationWidget->setBlue(arg1.toInt());
-    editedSinceLastSave = true;
+//    ui->AnimationWidget->setBlue(arg1.toInt());
+//    editedSinceLastSave = true;
 }
 
 void MainWindow::on_actionNew_File_triggered()

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -35,6 +35,7 @@ MainWindow::MainWindow(QWidget *parent) :
     connect(ui->resume, SIGNAL(released()), timeline, SLOT(resumePlayback()));
     connect(ui->stop, SIGNAL(released()), timeline, SLOT(stopPlayback()));
     connect(timeline, SIGNAL(scrollToSelected(TimelineView*)), this, SLOT(ScrollToSelected(TimelineView*)));
+    connect(ui->gotoCurrentFrame, SIGNAL(released()), timeline, SLOT(gotoCurrentFrame()));
 
     connect(timeline, SIGNAL(connectNewFrame(TimelineView*)), ui->AnimationWidget, SLOT(acceptFrameConnection(TimelineView*)));
 
@@ -55,8 +56,9 @@ void MainWindow::ScrollToSelected(TimelineView* view)
     qDebug() << "signaled";
     if(!rf->loading && !timeline->isPlaying)
         QTest::qWait(2);
-    ui->timelineArea->ensureVisible(view->pos().x()+100, 1);
-    ui->timelineArea->ensureVisible(view->pos().x(), 1);
+    ui->timelineArea->ensureVisible(view->pos().x(), 50);
+    ui->timelineArea->ensureVisible(view->pos().x()+200, 50);
+
 
     //ui->timelineArea->ensureVisible(100000000, 0, 0, 0);
 }

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -31,7 +31,9 @@ MainWindow::MainWindow(QWidget *parent) :
     connect(ui->moveButton, SIGNAL (released()), this, SLOT (moveButtonPress()));
     connect(ui->AddFrame, SIGNAL(released()), timeline, SLOT (addTimelineFrame()));
     connect(ui->delteFrame, SIGNAL(released()), timeline, SLOT(deleteCurrentView()));
-    connect(ui->playback, SIGNAL(released()), timeline, SLOT(playback()));
+    connect(ui->restart, SIGNAL(released()), timeline, SLOT(restartPlayback()));
+    connect(ui->resume, SIGNAL(released()), timeline, SLOT(resumePlayback()));
+    connect(ui->stop, SIGNAL(released()), timeline, SLOT(stopPlayback()));
 
     connect(timeline, SIGNAL(connectNewFrame(TimelineView*)), ui->AnimationWidget, SLOT(acceptFrameConnection(TimelineView*)));
 

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -8,6 +8,8 @@
 
 #include "global.h"
 #include "read.h"
+#include "timelineview.h"
+#include "timelinegraphics.h"
 
 namespace Ui {
 class MainWindow;
@@ -20,6 +22,8 @@ class MainWindow : public QMainWindow
 public:
     explicit MainWindow(QWidget *parent = 0);
     ~MainWindow();
+public slots:
+    void ScrollToSelected(TimelineView *view);
 private slots:
     void drawButtonPress();
     void eraseButtonPress();
@@ -52,6 +56,7 @@ private:
     QString fileName;
     bool editedSinceLastSave = false;
     readfile* rf;
+    TimelineGraphics* timeline;
 };
 
 #endif // MAINWINDOW_H

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -7,6 +7,7 @@
 #include <QHboxLayout>
 
 #include "global.h"
+#include "read.h"
 
 namespace Ui {
 class MainWindow;
@@ -50,6 +51,7 @@ private:
     void addTimelineFrame(QHBoxLayout* layout );
     QString fileName;
     bool editedSinceLastSave = false;
+    readfile* rf;
 };
 
 #endif // MAINWINDOW_H

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -27,7 +27,7 @@
        <widget class="QFrame" name="toolBar">
         <property name="maximumSize">
          <size>
-          <width>64</width>
+          <width>100</width>
           <height>16777215</height>
          </size>
         </property>
@@ -102,115 +102,10 @@
           </widget>
          </item>
          <item>
-          <layout class="QHBoxLayout" name="redEdit">
-           <item>
-            <widget class="QLabel" name="redLabel">
-             <property name="maximumSize">
-              <size>
-               <width>10</width>
-               <height>20</height>
-              </size>
-             </property>
-             <property name="text">
-              <string>R:</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QLineEdit" name="redLineEdit">
-             <property name="maximumSize">
-              <size>
-               <width>40</width>
-               <height>20</height>
-              </size>
-             </property>
-             <property name="maxLength">
-              <number>3</number>
-             </property>
-             <property name="dragEnabled">
-              <bool>false</bool>
-             </property>
-             <property name="placeholderText">
-              <string>0-255</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
+          <layout class="QHBoxLayout" name="redEdit"/>
          </item>
          <item>
-          <layout class="QHBoxLayout" name="greenEdit">
-           <item>
-            <widget class="QLabel" name="greenLabel">
-             <property name="maximumSize">
-              <size>
-               <width>10</width>
-               <height>20</height>
-              </size>
-             </property>
-             <property name="text">
-              <string>G:</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QLineEdit" name="greenLineEdit">
-             <property name="maximumSize">
-              <size>
-               <width>40</width>
-               <height>20</height>
-              </size>
-             </property>
-             <property name="maxLength">
-              <number>3</number>
-             </property>
-             <property name="dragEnabled">
-              <bool>false</bool>
-             </property>
-             <property name="placeholderText">
-              <string>0-255</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
-         <item>
-          <layout class="QHBoxLayout" name="blueEdit">
-           <item>
-            <widget class="QLabel" name="blueLabel">
-             <property name="maximumSize">
-              <size>
-               <width>10</width>
-               <height>20</height>
-              </size>
-             </property>
-             <property name="text">
-              <string>B:</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QLineEdit" name="blueLineEdit">
-             <property name="maximumSize">
-              <size>
-               <width>40</width>
-               <height>20</height>
-              </size>
-             </property>
-             <property name="inputMask">
-              <string/>
-             </property>
-             <property name="maxLength">
-              <number>3</number>
-             </property>
-             <property name="dragEnabled">
-              <bool>false</bool>
-             </property>
-             <property name="placeholderText">
-              <string>0-255</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
+          <layout class="QHBoxLayout" name="greenEdit"/>
          </item>
          <item>
           <spacer name="verticalSpacer_2">
@@ -224,22 +119,6 @@
             </size>
            </property>
           </spacer>
-         </item>
-         <item>
-          <widget class="QToolButton" name="keyFrameButton">
-           <property name="minimumSize">
-            <size>
-             <width>60</width>
-             <height>60</height>
-            </size>
-           </property>
-           <property name="cursor">
-            <cursorShape>PointingHandCursor</cursorShape>
-           </property>
-           <property name="text">
-            <string>KeyFrame</string>
-           </property>
-          </widget>
          </item>
          <item>
           <widget class="QPushButton" name="AddFrame">
@@ -298,7 +177,7 @@
        </layout>
       </item>
       <item>
-       <layout class="QVBoxLayout" name="colorSelector" stretch=""/>
+       <layout class="QVBoxLayout" name="colorSelector"/>
       </item>
      </layout>
     </item>

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -222,7 +222,7 @@
         <property name="minimumSize">
          <size>
           <width>0</width>
-          <height>225</height>
+          <height>300</height>
          </size>
         </property>
         <property name="verticalScrollBarPolicy">
@@ -237,7 +237,7 @@
            <x>0</x>
            <y>0</y>
            <width>1198</width>
-           <height>223</height>
+           <height>298</height>
           </rect>
          </property>
         </widget>

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -121,11 +121,38 @@
           </spacer>
          </item>
          <item>
-          <widget class="QPushButton" name="playback">
+          <widget class="QPushButton" name="resume">
            <property name="text">
-            <string>Play Animation</string>
+            <string>Resume Animation</string>
            </property>
           </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="restart">
+           <property name="text">
+            <string>Restart Animation</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="stop">
+           <property name="text">
+            <string>Stop Animation</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="verticalSpacer">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>40</height>
+            </size>
+           </property>
+          </spacer>
          </item>
          <item>
           <widget class="QPushButton" name="AddFrame">

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -155,6 +155,13 @@
           </spacer>
          </item>
          <item>
+          <widget class="QPushButton" name="gotoCurrentFrame">
+           <property name="text">
+            <string>Current Frame</string>
+           </property>
+          </widget>
+         </item>
+         <item>
           <widget class="QPushButton" name="AddFrame">
            <property name="text">
             <string>New Frame</string>

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -108,13 +108,6 @@
           <layout class="QHBoxLayout" name="greenEdit"/>
          </item>
          <item>
-          <widget class="QRadioButton" name="radioButton">
-           <property name="text">
-            <string>RadioButton</string>
-           </property>
-          </widget>
-         </item>
-         <item>
           <spacer name="verticalSpacer_2">
            <property name="orientation">
             <enum>Qt::Vertical</enum>

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -108,6 +108,13 @@
           <layout class="QHBoxLayout" name="greenEdit"/>
          </item>
          <item>
+          <widget class="QRadioButton" name="radioButton">
+           <property name="text">
+            <string>RadioButton</string>
+           </property>
+          </widget>
+         </item>
+         <item>
           <spacer name="verticalSpacer_2">
            <property name="orientation">
             <enum>Qt::Vertical</enum>
@@ -119,6 +126,13 @@
             </size>
            </property>
           </spacer>
+         </item>
+         <item>
+          <widget class="QPushButton" name="playback">
+           <property name="text">
+            <string>Play Animation</string>
+           </property>
+          </widget>
          </item>
          <item>
           <widget class="QPushButton" name="AddFrame">

--- a/pixel.cpp
+++ b/pixel.cpp
@@ -16,7 +16,7 @@ Pixel::Pixel(int x, int y, int size, QColor color, QGraphicsItem * parent)
     this->setPos(x,y);
 
     //output coords of new pixel for debugging
-    qDebug() << x << ", " << y;
+    //qDebug() << x << ", " << y;
 }
 
 QPointF Pixel::towerPos()

--- a/read.cpp
+++ b/read.cpp
@@ -225,6 +225,8 @@ int readfile::read(QString F_Name)
      }
 
      int frame_ct = 0;  //total number of frames
+     int totalMS = 0;
+     int duration = 0;
      do
      {
        line=stream.readLine(); //frame start time
@@ -246,8 +248,11 @@ int readfile::read(QString F_Name)
         ms = atoi(min_pt);
         printf(", ms: %d\n", ms);
       }
+      duration = totalMS;
+      totalMS = min * 60000 + sec * 1000 + ms;
+      duration = totalMS - duration;
+      printf("duration: = %d\n", duration);
 
-      int totalMS = min * 60000 + sec * 1000 + ms;
       int* MS = new int[grid.Frame_ct];
       MS[frame_ct] = totalMS;
       printf("total milliseconds = %d\n", MS[frame_ct]);
@@ -296,18 +301,29 @@ int readfile::read(QString F_Name)
       out << "Pixels contained in Frame# " << frame_ct+1 << endl;
       /*Printing out the linked list of 40 pixels that represents
       a frame...Used to confirm the linked list was created properly */
+      Frame* frame = new Frame(0, duration);
       for (Pixel_N pixel_n : p_frame)
       {
-              out << "R:" << pixel_n.getRval() << ", "
-                  << "G:" << pixel_n.getGval() << ", "
-                  << "B:" << pixel_n.getBval() << ", "
-                  << "X:" << pixel_n.getXval() << ", "
-                  << "Y:" << pixel_n.getYval() << ", "
-                  << endl;
-       }
+//         qDebug() << "R:" << pixel_n.getRval() << ", "
+//                  << "G:" << pixel_n.getGval() << ", "
+//                  << "B:" << pixel_n.getBval() << ", "
+//                  << "X:" << pixel_n.getXval() << ", "
+//                  << "Y:" << pixel_n.getYval() << ", "
+//                  << endl;
+         QColor color;
+         color.setRed(pixel_n.getRval());
+         color.setGreen(pixel_n.getGval());
+         color.setBlue(pixel_n.getBval());
+         Pixel* p = new Pixel(pixel_n.getXval() * Globals::GRID_SIZE + Globals::TOWER_POSITION_X, pixel_n.getYval() * Globals::GRID_SIZE + Globals::TOWER_POSITION_Y, Globals::PIXEL_SIZE, color);
+         frame->addPixel(p);
 
-        frame_ct++; //increment the frame counter
-     }while(!line.isNull());
+       }
+       emit loadFrame(frame);
+       frame_ct++; //increment the frame counter
+       if(frame_ct % 50 == 0)
+           QTest::qWait(1);
+     }//while(frame_ct < 100);
+     while(!line.isNull());
 
    }
 

--- a/read.cpp
+++ b/read.cpp
@@ -9,7 +9,7 @@
 //int LIST_InsertHeadNode(Pixel_List_N **, int, int, int, int, int);
 readfile::readfile()
 {
-
+    loading = false;
 }
 
 int readfile::read(QString F_Name)
@@ -229,6 +229,7 @@ int readfile::read(QString F_Name)
      int duration = 0;
      do
      {
+       loading = true;
        line=stream.readLine(); //frame start time
        /*Convert the old style time to the new format in milliseconds
        using ":" and "." as the respective delimiters */
@@ -324,7 +325,7 @@ int readfile::read(QString F_Name)
            QTest::qWait(1);
      }//while(frame_ct < 100);
      while(!line.isNull());
-
+     loading = false;
    }
 
  }

--- a/read.h
+++ b/read.h
@@ -15,6 +15,7 @@ public:
     virtual ~readfile() {};
     readfile();
     int read(QString);
+    bool loading;
 };
 
 #endif // READ_H

--- a/read.h
+++ b/read.h
@@ -1,10 +1,18 @@
 #ifndef READ_H
 #define READ_H
 #include<QString>
+#include <QObject>
+#include <QTest>
+#include "frame.h"
+#include "pixel.h"
 
-class readfile
+class readfile : public QObject
 {
+    Q_OBJECT
+signals:
+    void loadFrame(Frame*);
 public:
+    virtual ~readfile() {};
     readfile();
     int read(QString);
 };

--- a/storagetimeline.cpp
+++ b/storagetimeline.cpp
@@ -30,6 +30,7 @@ void storageTimeline::addFrame(double duration)
 void storageTimeline::addFrame(Frame* frame)
 {
     frames.append(frame);
+    numOfFrames++;
 }
 
 void storageTimeline::removeFrame(int frameNum)

--- a/storagetimeline.cpp
+++ b/storagetimeline.cpp
@@ -37,15 +37,17 @@ void storageTimeline::removeFrame(int frameNum)
 {
     // iterate through list until correct frame number is found
 
-    int timelineSize = frames.size();
+//    int timelineSize = frames.size();
 
-    for(int index=0; index<timelineSize; index++)
-    {
-       if(frames[index]->frameNumber==frameNum)
-       {
-           frames.removeAt(index);
-       }
-    }
+//    for(int index=0; index<timelineSize; index++)
+//    {
+//       if(frames[index]->frameNumber==frameNum)
+//       {
+//           frames.removeAt(index);
+//       }
+//    }
+    frames.removeAt(frameNum);
+    numOfFrames--;
 }
 
 void storageTimeline::moveFrames(int startFrameNum, int endFrameNum, int newLocation)

--- a/storagetimeline.h
+++ b/storagetimeline.h
@@ -4,7 +4,6 @@ class storageTimeline
 {
 private:
     int numOfFrames; // track number of frames created
-    int getNumOfFrames();
 public:
     int currFrame; // ??
     QList<class Frame *> frames; //possibly needs to be <Frame *>
@@ -18,4 +17,5 @@ public:
     void removeFrame(int frameNum);
     void moveFrames(int startFrameNum, int endFrameNum, int newLocation);
     void addFrame(Frame *frame);
+    int getNumOfFrames();
 };

--- a/struct.h
+++ b/struct.h
@@ -18,7 +18,7 @@ typedef struct Layout
     int Width;
 }Layout_N;
 
-typedef struct Pixel
+typedef struct loadPixel
 {
    int R;
    int G;
@@ -37,27 +37,27 @@ typedef struct Pixel
 }Pixel_N;
 
 //used for printing out the values of the pixels
-int Pixel::getRval() const
+int loadPixel::getRval() const
 {
   return R;
 }
-int Pixel::getGval() const
+int loadPixel::getGval() const
 {
   return G;
 }
-int Pixel::getBval() const
+int loadPixel::getBval() const
 {
   return B;
 }
-int Pixel::getXval() const
+int loadPixel::getXval() const
 {
   return X;
 }
-int Pixel::getYval() const
+int loadPixel::getYval() const
 {
   return Y;
 }
-int Pixel::getCTval() const
+int loadPixel::getCTval() const
 {
   return CT;
 }

--- a/timelinegraphics.cpp
+++ b/timelinegraphics.cpp
@@ -87,8 +87,19 @@ void TimelineGraphics::deleteCurrentView()
 
     //select a new frame based on index of last frame
     QLayoutItem* item = layout->itemAt(index);
-    TimelineView* view2 = item->widget();
-    //frameLayout = item->layout();
-    emit view2->iWasSelected(view2);
+    if(item)
+    {
+        TimelineView* view2 = item->widget();
+        emit view2->iWasSelected(view2);
+    }
+    else {
+        item = layout->itemAt(index-1);
+        if(item) {
+            TimelineView* view2 = item->widget();
+            emit view2->iWasSelected(view2);
+        } else {
+            addTimelineFrame();
+        }
+    }
 }
 

--- a/timelinegraphics.cpp
+++ b/timelinegraphics.cpp
@@ -24,6 +24,7 @@ void TimelineGraphics::loadTimeline()
 {
     timeline->setLayout(this->layout);
     timeline->setMaximumHeight(500);
+    selectedView = NULL;
 }
 
 void TimelineGraphics::addFramePixel(QGraphicsScene* scene, int x, int y)
@@ -64,7 +65,10 @@ void TimelineGraphics::addTimelineFrame()
 
 void TimelineGraphics::currentFrame(TimelineView* view)
 {
+    if(selectedView)
+        selectedView->setBackgroundBrush(Qt::white);
     this->selectedView = view;
+    selectedView->setBackgroundBrush(Qt::lightGray);
 }
 
 void TimelineGraphics::deleteView(TimelineView* view)
@@ -73,12 +77,17 @@ void TimelineGraphics::deleteView(TimelineView* view)
     layout->removeWidget(view);
     timelinelist->removeFrame(view->frame);
     delete view;
+    selectedView = NULL;
 }
 
 void TimelineGraphics::deleteCurrentView()
 {
     // get index of view to be deleted
+    if(!selectedView)
+        return 0;
     TimelineView* view = this->selectedView;
+    if(!view)
+        return 0;
     int index = layout->indexOf(view);
     std::cout << index;
 
@@ -86,6 +95,7 @@ void TimelineGraphics::deleteCurrentView()
     deleteView(this->selectedView);
 
     //select a new frame based on index of last frame
+
     QLayoutItem* item = layout->itemAt(index);
     if(item)
     {

--- a/timelinegraphics.cpp
+++ b/timelinegraphics.cpp
@@ -36,8 +36,13 @@ void TimelineGraphics::addFramePixel(QGraphicsScene* scene, int x, int y)
 
 void TimelineGraphics::addTimelineFrame()
 {
+    addTimelineFrame(new Frame(0,1));
+}
+
+void TimelineGraphics::addTimelineFrame(Frame* scene)
+{
     TimelineView* view = new TimelineView;
-    Frame* scene = new Frame(timelinelist->getNumOfFrames());
+    //Frame* scene = new Frame(timelinelist->getNumOfFrames());
 
     //initialize the view
     view->frame = scene;
@@ -60,7 +65,7 @@ void TimelineGraphics::addTimelineFrame()
     this->layout->addWidget(view);
 
     //add to storage class
-    //timelinelist->addFrame(scene);
+    timelinelist->addFrame(scene);
 }
 
 void TimelineGraphics::currentFrame(TimelineView* view)
@@ -75,6 +80,7 @@ void TimelineGraphics::deleteView(TimelineView* view)
 {
     //remove the layout
     layout->removeWidget(view);
+    timelinelist->removeFrame(layout->indexOf(view));
     //timelinelist->removeFrame(view->frame->frameNumber);
     delete view->frame;
     delete view;
@@ -114,3 +120,17 @@ void TimelineGraphics::deleteCurrentView()
     }
 }
 
+void TimelineGraphics::playback()
+{
+//    QList::Iterator i;
+//    for (i = timelinelist->frames.begin(); i != list.end(); ++i) {
+//        emit timelinelist[i].
+//    }
+    QLayoutItem* item;
+    TimelineView* view;
+    for(int i = 0; item = layout->itemAt(i); i++) {
+        view = item->widget();
+        emit view->iWasSelected(view);
+        QTest::qWait(view->frame->duration);
+    }
+}

--- a/timelinegraphics.cpp
+++ b/timelinegraphics.cpp
@@ -164,3 +164,8 @@ void TimelineGraphics::stopPlayback()
 {
     isPlaying = false;
 }
+
+void TimelineGraphics::gotoCurrentFrame()
+{
+    emit selectedView->iWasSelected(selectedView);
+}

--- a/timelinegraphics.cpp
+++ b/timelinegraphics.cpp
@@ -37,7 +37,7 @@ void TimelineGraphics::addFramePixel(QGraphicsScene* scene, int x, int y)
 void TimelineGraphics::addTimelineFrame()
 {
     TimelineView* view = new TimelineView;
-    Frame* scene = new Frame;
+    Frame* scene = new Frame(timelinelist->getNumOfFrames());
 
     //initialize the view
     view->frame = scene;
@@ -60,7 +60,7 @@ void TimelineGraphics::addTimelineFrame()
     this->layout->addWidget(view);
 
     //add to storage class
-    timelinelist->addFrame(scene);
+    //timelinelist->addFrame(scene);
 }
 
 void TimelineGraphics::currentFrame(TimelineView* view)
@@ -75,7 +75,8 @@ void TimelineGraphics::deleteView(TimelineView* view)
 {
     //remove the layout
     layout->removeWidget(view);
-    timelinelist->removeFrame(view->frame);
+    //timelinelist->removeFrame(view->frame->frameNumber);
+    delete view->frame;
     delete view;
     selectedView = NULL;
 }

--- a/timelinegraphics.cpp
+++ b/timelinegraphics.cpp
@@ -25,6 +25,7 @@ void TimelineGraphics::loadTimeline()
     timeline->setLayout(this->layout);
     timeline->setMaximumHeight(500);
     selectedView = NULL;
+    isPlaying = false;
 }
 
 void TimelineGraphics::addFramePixel(QGraphicsScene* scene, int x, int y)
@@ -120,17 +121,35 @@ void TimelineGraphics::deleteCurrentView()
     }
 }
 
-void TimelineGraphics::playback()
+void TimelineGraphics::playback(int start)
 {
-//    QList::Iterator i;
-//    for (i = timelinelist->frames.begin(); i != list.end(); ++i) {
-//        emit timelinelist[i].
+//    if(isPlaying) {
+//        isPlaying = false;
+//        return 0;
 //    }
+    isPlaying = true;
     QLayoutItem* item;
     TimelineView* view;
-    for(int i = 0; item = layout->itemAt(i); i++) {
+    for(int i = start; item = layout->itemAt(i); i++) {
         view = item->widget();
         emit view->iWasSelected(view);
         QTest::qWait(view->frame->duration);
+        if(!isPlaying)
+            return 0;
     }
+}
+
+void TimelineGraphics::restartPlayback()
+{
+    playback(0);
+}
+
+void TimelineGraphics::resumePlayback()
+{
+    playback(layout->indexOf(selectedView));
+}
+
+void TimelineGraphics::stopPlayback()
+{
+    isPlaying = false;
 }

--- a/timelinegraphics.cpp
+++ b/timelinegraphics.cpp
@@ -60,21 +60,32 @@ void TimelineGraphics::addTimelineFrame(Frame* scene)
     connect(view, SIGNAL (iWasSelected(TimelineView*)), this, SLOT (currentFrame(TimelineView*)));
 
     //make the new frame the selected frame
-    emit view->iWasSelected(view);
 
-    //add to layout
-    this->layout->addWidget(view);
+
+    //add to layout inserting after currently selected frame
+    int index = 0;
+    if (selectedView) {
+        index = layout->indexOf(this->selectedView);
+    }
+    qDebug() << index;
+    layout->insertWidget(index+1, view);
+
 
     //add to storage class
     timelinelist->addFrame(scene);
+
+    //set focus
+    emit view->iWasSelected(view);
 }
 
 void TimelineGraphics::currentFrame(TimelineView* view)
 {
-    if(selectedView)
+    if(selectedView) {
         selectedView->setBackgroundBrush(Qt::white);
+    }
     this->selectedView = view;
-    selectedView->setBackgroundBrush(Qt::lightGray);
+    selectedView->setBackgroundBrush(Qt::black);
+    emit scrollToSelected(selectedView);
 }
 
 void TimelineGraphics::deleteView(TimelineView* view)
@@ -97,7 +108,7 @@ void TimelineGraphics::deleteCurrentView()
     if(!view)
         return 0;
     int index = layout->indexOf(view);
-    std::cout << index;
+    qDebug() << index;
 
     //delete the view
     deleteView(this->selectedView);

--- a/timelinegraphics.h
+++ b/timelinegraphics.h
@@ -9,6 +9,7 @@
 #include <QWidget>
 #include <QHBoxLayout>
 #include <QGraphicsScene>
+#include <QTest>
 
 class TimelineGraphics : public QObject
 {
@@ -31,9 +32,11 @@ private:
 
 public slots:
     void addTimelineFrame();
+    void addTimelineFrame(Frame *scene);
     void currentFrame(TimelineView *view);
 
     void deleteCurrentView();
+    void playback();
 };
 
 #endif // TIMELINEGRAPHICS_H

--- a/timelinegraphics.h
+++ b/timelinegraphics.h
@@ -44,6 +44,7 @@ public slots:
     void resumePlayback();
     void restartPlayback();
     void stopPlayback();
+    void gotoCurrentFrame();
 };
 
 #endif // TIMELINEGRAPHICS_H

--- a/timelinegraphics.h
+++ b/timelinegraphics.h
@@ -29,6 +29,8 @@ private:
     TimelineView* selectedView;
     void deleteView(TimelineView *view);
     storageTimeline* timelinelist;
+    bool isPlaying;
+    void playback(int start);
 
 public slots:
     void addTimelineFrame();
@@ -36,7 +38,10 @@ public slots:
     void currentFrame(TimelineView *view);
 
     void deleteCurrentView();
-    void playback();
+
+    void resumePlayback();
+    void restartPlayback();
+    void stopPlayback();
 };
 
 #endif // TIMELINEGRAPHICS_H

--- a/timelinegraphics.h
+++ b/timelinegraphics.h
@@ -16,20 +16,22 @@ class TimelineGraphics : public QObject
     Q_OBJECT
 signals:
     void connectNewFrame(TimelineView*);
+    void scrollToSelected(TimelineView*);
 public:
     TimelineGraphics();
     void loadTimeline();
     void addFramePixel(QGraphicsScene* scene, int x, int y);
     QWidget* timelineWidget();
-
+    QHBoxLayout* layout;
+    bool isPlaying;
 
 private:
     QWidget* timeline;
-    QHBoxLayout* layout;
+
     TimelineView* selectedView;
     void deleteView(TimelineView *view);
     storageTimeline* timelinelist;
-    bool isPlaying;
+
     void playback(int start);
 
 public slots:


### PR DESCRIPTION
Frames now load into timeline view and storage timeline list from input file. Playback button allows playback of current timeline. timelineview and storage timeline are in sync. Currently selected frame is now highlighted. Bug fixes on frame deletion. playback can be restarted, resumed, and paused. selecting a frame by deletion, insertion ,playback, or manually will snap to that frame in the scroll area. 
![image](https://cloud.githubusercontent.com/assets/16008906/20925757/8ee34636-bb6d-11e6-8143-a21299f1ecbb.png)

