### PR TITLE
Durations now work properly in timline playback for tan and tan2

### DIFF
--- a/read.cpp
+++ b/read.cpp
@@ -2,11 +2,6 @@
 #include "struct.h"
 
 
-//Path to  the tan file on your local machine
-//QString F_Name = "C:/Users/colton/Documents/parser/gtr.TAN2";
-
-//declarations
-//int LIST_InsertHeadNode(Pixel_List_N **, int, int, int, int, int);
 readfile::readfile()
 {
     loading = false;
@@ -46,8 +41,6 @@ int readfile::read(QString F_Name)
     //Version number determines how to parse the file
     if(ver2 == 4)
     {
-
-
       //frame count and window dimentions need to split up the 3 pieces of information to pass on
       line = stream.readLine()+ '\n';
       QByteArray lin = line.toLatin1();
@@ -77,39 +70,22 @@ int readfile::read(QString F_Name)
 
         int* MS = new int[grid.Frame_ct];
         MS[0] = 0;
-        int duration = 0;
+
         //Int to place frame number in each pixel
         int frame_ct = 0;
+        line=stream.readLine();//initial frame start time
+        MS[frame_ct] = 0;
+        frame_ct++;
         do
         {
           loading = true;
-          line=stream.readLine(); //frame start time
-
-          //Read in the frame time stamp
-          QByteArray time_1 = line.toLatin1();
           int ms_1;
           int duration = 0;
-          char *time1_str = time_1.data();
-          char *ms_pt = NULL;
-          ms_pt = strtok(time1_str, " ");
 
-          if(ms_pt != NULL)
-          {
-            ms_1 = atoi(ms_pt);
-            printf("milliseconds: %d\n", ms_1);
-          }
-
-          //int* MS_1 = new int[grid.Frame_ct];
-          MS[frame_ct] = ms_1;
-          duration =( MS[frame_ct] - MS[frame_ct - 1] );
-
-
-          //duration = MS[frame_ct] - duration;
-          printf("duration: = %d\n", duration);
+          //printf("duration: = %d\n", duration);
 
           //Create the Linked List that will store the individual frames.
           QLinkedList<Pixel_N> p_frame;
-          //QLinkedList<Pixel_N>::iterator iterator;
 
           //This loop will iterate through the frame and populate the linked list based on the height and width of the input file
           //Skip the first 5 lines of empty pixels from the file
@@ -159,7 +135,7 @@ int readfile::read(QString F_Name)
                 pix.B = b;
                 pix.X = pix_x_val;
                 pix.Y = pix_y_val;
-                pix.CT = frame_ct+1;
+                pix.CT = frame_ct;
                 p_frame.append(pix);
 
                 //increment the X position value
@@ -184,39 +160,51 @@ int readfile::read(QString F_Name)
           line=stream.readLine();
           line=stream.readLine();
 
+          //Read in the frame time stamp
+          line=stream.readLine();
+          QByteArray time_1 = line.toLatin1();
+          char *time1_str = time_1.data();
+          char *ms_pt = NULL;
+          ms_pt = strtok(time1_str, " ");
+          if(ms_pt != NULL)
+          {
+            ms_1 = atoi(ms_pt);
+            //printf("milliseconds: %d\n", ms_1);
+          }
+          //Set the frame duration
+          MS[frame_ct] = ms_1;
+          /* Frame duration = current timestamp - previous timestamp */
+          duration =( MS[frame_ct] - MS[frame_ct - 1] );
 
-          //Print out the frame of 40 pixels
-
+          /*Print out the frame of 40 pixels*/
           //out << "Pixels contained in Frame# " << frame_ct+1 << endl;
-          /*Printing out the linked list of 40 pixels that represents
-          a frame...Used to confirm the linked list was created properly */
+          /* Create the frames of 40 pixels*/
           Frame* frame = new Frame(0, duration);
           for (Pixel_N pixel_n : p_frame)
           {
                  // out << "R:" << pixel_n.getRval() << ", "
                  //     << "G:" << pixel_n.getGval() << ", "
-                   //   << "B:" << pixel_n.getBval() << ", "
-                   //   << "X:" << pixel_n.getXval() << ", "
-                    //  << "Y:" << pixel_n.getYval() << ", "
-                    //  << endl;
+                 //     << "B:" << pixel_n.getBval() << ", "
+                 //     << "X:" << pixel_n.getXval() << ", "
+                 //     << "Y:" << pixel_n.getYval() << ", "
+                 //     << endl;
               QColor color;
               color.setRed(pixel_n.getRval());
               color.setGreen(pixel_n.getGval());
               color.setBlue(pixel_n.getBval());
-
-              if(!(color.red() == 0 && color.green() == 0 && color.blue() == 0 )){
-                Pixel* p = new Pixel(pixel_n.getXval() * Globals::GRID_SIZE + Globals::TOWER_POSITION_X, pixel_n.getYval() * Globals::GRID_SIZE + Globals::TOWER_POSITION_Y, Globals::PIXEL_SIZE, color);
-                frame->addPixel(p);
-              }
+              Pixel* p = new Pixel(pixel_n.getXval() * Globals::GRID_SIZE + Globals::TOWER_POSITION_X, pixel_n.getYval() * Globals::GRID_SIZE + Globals::TOWER_POSITION_Y, Globals::PIXEL_SIZE, color);
+              frame->addPixel(p);
            }
            emit loadFrame(frame);
            //increment the frame number counter
-           frame_ct++;
-           if(frame_ct % 50 == 0)
+
+           if(frame_ct % 100 == 0)
                QTest::qWait(1);
+           frame_ct++;
        }while(!line.isNull());
        loading = false;
      }
+      file.close();
       return 0;
    }
    else
@@ -247,38 +235,17 @@ int readfile::read(QString F_Name)
 
      int frame_ct = 0;  //total number of frames
      int totalMS = 0;
-     int duration = 0;
+     int duration = 0;   
+     int* MS = new int[grid.Frame_ct];
+     MS[0] = 0;
+     MS[frame_ct] = totalMS;
+     line=stream.readLine();//initial frame start time
+     MS[frame_ct] = 0;
+     frame_ct++;
+
      do
      {
        loading = true;
-       line=stream.readLine(); //frame start time
-       /*Convert the old style time to the new format in milliseconds
-       using ":" and "." as the respective delimiters */
-       QByteArray time = line.toLatin1();
-       int min, sec, ms;
-       char *time_str = time.data();
-       char *min_pt = NULL;
-       min_pt = strtok(time_str, ":");
-       if(min_pt != NULL)
-       {
-        min = atoi(min_pt);
-        printf("min: %d", min);
-        min_pt = strtok(NULL, ":.");
-        sec = atoi(min_pt);
-        printf(", sec: %d", sec);
-        min_pt = strtok(NULL, ".");
-        ms = atoi(min_pt);
-        printf(", ms: %d\n", ms);
-      }
-      duration = totalMS;
-      totalMS = min * 60000 + sec * 1000 + ms;
-      duration = totalMS - duration;
-      printf("duration: = %d\n", duration);
-
-      int* MS = new int[grid.Frame_ct];
-      MS[frame_ct] = totalMS;
-      printf("total milliseconds = %d\n", MS[frame_ct]);
-
       //Create the Linked List that will store the individual frames.
       QLinkedList<Pixel_N> p_frame;
       int pix_y_val = 0; //y position value for linked list
@@ -310,7 +277,7 @@ int readfile::read(QString F_Name)
           pix.B = b;
           pix.X = pix_x_val;
           pix.Y = pix_y_val;
-          pix.CT = frame_ct+1;
+          pix.CT = frame_ct;
           p_frame.append(pix);
 
           //increment the X position value
@@ -320,7 +287,34 @@ int readfile::read(QString F_Name)
        pix_y_val++;
       }
       //Print out the frame of 40 pixels
-      out << "Pixels contained in Frame# " << frame_ct+1 << endl;
+
+      line=stream.readLine(); //frame start time
+      /*Convert the old style time to the new format in milliseconds
+      using ":" and "." as the respective delimiters */
+      QByteArray time = line.toLatin1();
+      int min, sec, ms;
+      char *time_str = time.data();
+      char *min_pt = NULL;
+      min_pt = strtok(time_str, ":");
+      if(min_pt != NULL)
+      {
+       min = atoi(min_pt);
+       //printf("min: %d", min);
+       min_pt = strtok(NULL, ":.");
+       sec = atoi(min_pt);
+       //printf(", sec: %d", sec);
+       min_pt = strtok(NULL, ".");
+       ms = atoi(min_pt);
+       //printf(", ms: %d\n", ms);
+     }
+     duration = totalMS;
+     totalMS = min * 60000 + sec * 1000 + ms;
+     duration = totalMS - duration;
+     //printf("duration: = %d\n", duration);
+
+
+     //printf("total milliseconds = %d\n", MS[frame_ct]);
+     // out << "Pixels contained in Frame# " << frame_ct << endl;
       /*Printing out the linked list of 40 pixels that represents
       a frame...Used to confirm the linked list was created properly */
       Frame* frame = new Frame(0, duration);
@@ -336,25 +330,24 @@ int readfile::read(QString F_Name)
          color.setRed(pixel_n.getRval());
          color.setGreen(pixel_n.getGval());
          color.setBlue(pixel_n.getBval());
-
-         if(!(color.red() == 0 && color.green() == 0 && color.blue() == 0 )){
-            Pixel* p = new Pixel(pixel_n.getXval() * Globals::GRID_SIZE + Globals::TOWER_POSITION_X, pixel_n.getYval() * Globals::GRID_SIZE + Globals::TOWER_POSITION_Y, Globals::PIXEL_SIZE, color);
-            frame->addPixel(p);
-         }
+         Pixel* p = new Pixel(pixel_n.getXval() * Globals::GRID_SIZE + Globals::TOWER_POSITION_X, pixel_n.getYval() * Globals::GRID_SIZE + Globals::TOWER_POSITION_Y, Globals::PIXEL_SIZE, color);
+         frame->addPixel(p);
 
        }
        emit loadFrame(frame);
-       frame_ct++; //increment the frame counter
-       if(frame_ct % 50 == 0)
+
+       if(frame_ct % 100 == 0)
            QTest::qWait(1);
+        frame_ct++; //increment the frame counter
      }//while(frame_ct < 100);
      while(!line.isNull());
      loading = false;
    }
 
  }
+  file.close();
   return 0;
 
-   file.close();
+
    qDebug() << "Reading finished";
 }

--- a/timelinegraphics.cpp
+++ b/timelinegraphics.cpp
@@ -52,7 +52,7 @@ void TimelineGraphics::addTimelineFrame(Frame* scene)
     view->setScene(scene);
     //view->setMaximumWidth(80);
     view->setFixedSize(Globals::TOWER_WIDTH, Globals::TOWER_HEIGHT);
-   // view->setMaximumHeight(200);
+    // view->setMaximumHeight(200);
     //view->scale(0.5, 0.5);
 
     //make connections


### PR DESCRIPTION
Cleaned up the readfile and frame duration is no longer off by one.